### PR TITLE
ci: enforce least-privilege permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -7,6 +7,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -25,6 +25,8 @@ on:
         required: false
         default: false
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/nix-image.yaml
+++ b/.github/workflows/nix-image.yaml
@@ -22,6 +22,8 @@ on:
         description: Image reference
         value: ${{ jobs.build.outputs.image-ref }}
 
+permissions: {}
+
 jobs:
   amd64:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Enforce least-privilege permissions

This PR adds explicit `permissions` blocks to GitHub Actions workflow files that currently have no permissions defined, following the principle of least privilege.

### Changes
- `cargo.yml`: contents: read
- `image.yml`: permissions: {} (defense-in-depth)
- `nix-image.yaml`: permissions: {} (defense-in-depth)

### Why
Without explicit permissions, workflows inherit the default token permissions configured at the repository or organization level. By explicitly declaring the minimum required permissions, we reduce the blast radius if a workflow is compromised.

### References
- [GitHub Actions security hardening](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions)
- [Automatic token authentication permissions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
